### PR TITLE
New telos.proxy smart contract for proxy info registration

### DIFF
--- a/telos.proxy/CMakeLists.txt
+++ b/telos.proxy/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_contract(telos.proxy telos.proxy ${CMAKE_CURRENT_SOURCE_DIR}/src/telos.proxy.cpp)
+target_include_directories(telos.proxy.wasm
+   PUBLIC
+   ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+set_target_properties(telos.proxy.wasm
+   PROPERTIES
+   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")

--- a/telos.proxy/README.md
+++ b/telos.proxy/README.md
@@ -1,0 +1,87 @@
+# Telos Proxy Info
+This is an on-chain Telos contract that allows Telos proxy accounts to register additional information about themselves, such as name and website. This information is published on the Telos blockchain, is accessible via the [Sqrl Wallet](https://github.com/Telos-Foundation/Sqrl) and freely available to be republished. An example website that uses this information on the EOS chain is the [Aloha EOS Proxy Research Portal](https://www.alohaeos.com/vote/proxy).
+
+The contract should be published on the `telos.proxy` account on the Telos mainnet.
+
+## GUI Usage
+
+For a GUI tool that interacts with this dApp try the following:
+
+- [Telos' Sqrl Wallet by EOS Miami](https://github.com/Telos-Foundation/Sqrl)
+
+## Command Line Usage
+
+First thing, you should already have a Telos proxy account that you have run `regproxy` on. Run `teclos system regproxy` for further instructions.
+
+### Set
+
+The set action inserts or updates information about your account. The paramaters are:
+- **proxy** (required): Your Telos account name.
+- **name** (required, 64 char max): The full name of your proxy.
+- **slogan** (optional, 64 char max): A short description of your proxy intended to be shown in listings.
+- **philosophy** (optional, 1024 char max): Description of proxy's voting philosophy.
+- **background** (optional, 1024 char max): Background information / who is the proxy?
+- **website** (optional, 256 char max): An http or https URL to a website, Reddit post, etc. with more information about your proxy.
+- **logo_256** (optional, 256 char max): An http or https URL to an image with the size of 256 x 256 px.
+- **telegram** (optional, 64 char max): Telegram account name.
+- **steemit** (optional, 64 char max): Steemit account name.
+- **twitter** (optional, 64 char max): Twitter account name.
+- **wechat** (optional, 64 char max): WeChat account name.
+
+Note: This action will consume a little bit of your RAM for the storage. How much depends on the length of your data, but probably around 1kb.
+
+teclos example:
+```
+teclos -u https://api.eos.miami push action telos.proxy set '["myproxyaccnt","My Proxy Name","For a better world","Voting philosophy","","https://my.proxy.website/","","","","",""]' -p myproxyaccnt
+```
+
+### Remove
+
+The remove action will remove all information about your account. The parameters are:
+- proxy: Your Telos account name.
+
+teclos example:
+```
+teclos -u https://api.eos.miami push action telos.proxy remove '["myproxyaccnt"]' -p myproxyaccnt
+
+```
+
+## Getting the Data
+
+All data is stored in the `proxies` table on the `telos.proxy` account.
+
+teclos example:
+```
+teclos -u https://api.eos.miami get table telos.proxy telos.proxy proxies
+{
+  "rows": [{
+      "owner": "myproxyaccnt",
+      "name": "My Proxy Name",
+      "website": "https://my.proxy.website/"
+    }
+  ],
+  "more": false
+}
+```
+
+curl example:
+```
+curl -d '{"json":true,"code":"telos.proxy","scope":"telos.proxy","table":"proxies","limit":100}' -s 'https://api.eos.miami/v1/chain/get_table_rows' | jq
+{
+  "rows": [{
+      "owner": "myproxyaccnt",
+      "name": "My Proxy Name",
+      "website": "https://my.proxy.website/"
+    }
+  ],
+  "more": false
+}
+```
+
+## Feedback
+Questions or comments? Drop us a comment in [Telos Foundation](https://t.me/hellotelos) channel on Telegram.
+
+## Acknowledgements
+These are the people or teams that helped contribute to this project (in alphabetical order):
+- [Aloha EOS](https://www.alohaeos.com/) developed the initial version of this contract for the EOS chain.
+- [EOS Miami](https://eos.miami) migrated and incorporated this into the Sqrl wallet.

--- a/telos.proxy/README.md
+++ b/telos.proxy/README.md
@@ -1,7 +1,7 @@
 # Telos Proxy Info
 This is an on-chain Telos contract that allows Telos proxy accounts to register additional information about themselves, such as name and website. This information is published on the Telos blockchain, is accessible via the [Sqrl Wallet](https://github.com/Telos-Foundation/Sqrl) and freely available to be republished. An example website that uses this information on the EOS chain is the [Aloha EOS Proxy Research Portal](https://www.alohaeos.com/vote/proxy).
 
-The contract should be published on the `telos.proxy` account on the Telos mainnet.
+The contract should be published on the `tlsproxyinfo` account on the Telos mainnet.
 
 ## GUI Usage
 
@@ -32,7 +32,7 @@ Note: This action will consume a little bit of your RAM for the storage. How muc
 
 teclos example:
 ```
-teclos -u https://api.eos.miami push action telos.proxy set '["myproxyaccnt","My Proxy Name","For a better world","Voting philosophy","","https://my.proxy.website/","","","","",""]' -p myproxyaccnt
+teclos -u https://api.eos.miami push action tlsproxyinfo set '["myproxyaccnt","My Proxy Name","For a better world","Voting philosophy","","https://my.proxy.website/","","","","",""]' -p myproxyaccnt
 ```
 
 ### Remove
@@ -42,17 +42,17 @@ The remove action will remove all information about your account. The parameters
 
 teclos example:
 ```
-teclos -u https://api.eos.miami push action telos.proxy remove '["myproxyaccnt"]' -p myproxyaccnt
+teclos -u https://api.eos.miami push action tlsproxyinfo remove '["myproxyaccnt"]' -p myproxyaccnt
 
 ```
 
 ## Getting the Data
 
-All data is stored in the `proxies` table on the `telos.proxy` account.
+All data is stored in the `proxies` table on the `tlsproxyinfo` account.
 
 teclos example:
 ```
-teclos -u https://api.eos.miami get table telos.proxy telos.proxy proxies
+teclos -u https://api.eos.miami get table tlsproxyinfo tlsproxyinfo proxies
 {
   "rows": [{
       "owner": "myproxyaccnt",
@@ -66,7 +66,7 @@ teclos -u https://api.eos.miami get table telos.proxy telos.proxy proxies
 
 curl example:
 ```
-curl -d '{"json":true,"code":"telos.proxy","scope":"telos.proxy","table":"proxies","limit":100}' -s 'https://api.eos.miami/v1/chain/get_table_rows' | jq
+curl -d '{"json":true,"code":"tlsproxyinfo","scope":"tlsproxyinfo","table":"proxies","limit":100}' -s 'https://api.eos.miami/v1/chain/get_table_rows' | jq
 {
   "rows": [{
       "owner": "myproxyaccnt",

--- a/telos.proxy/include/telos.proxy/telos.proxy.hpp
+++ b/telos.proxy/include/telos.proxy/telos.proxy.hpp
@@ -1,0 +1,55 @@
+/**
+ * Supports chain storage of proxies
+ * 
+ * @author Marlon Williams
+ * @copyright defined in telos/LICENSE.txt
+ */
+
+#pragma once
+
+#include <eosiolib/eosio.hpp>
+
+#include <string>
+
+using namespace std;
+using namespace eosio;
+
+class [[eosio::contract("telos.proxy")]] tlsproxyinfo : public contract {
+    public:
+      using contract::contract;
+
+      [[eosio::action]]
+      void set(const name proxy, std::string name, std::string slogan, std::string philosophy, std::string background, std::string website, std::string logo_256, std::string telegram, std::string steemit, std::string twitter, std::string wechat, std::string reserved_1, std::string reserved_2, std::string reserved_3);
+
+      [[eosio::action]]
+      void remove(const name proxy);
+
+      struct [[eosio::table]] proxy {
+            name owner;
+            std::string name;
+            std::string website;
+            std::string slogan;
+            std::string philosophy;
+            std::string background;
+            std::string logo_256;
+            std::string telegram;
+            std::string steemit;
+            std::string twitter;
+            std::string wechat;
+            std::string reserved_1;
+            std::string reserved_2;
+            std::string reserved_3;
+
+            auto primary_key()const { return owner.value; }
+            EOSLIB_SERIALIZE(proxy, (owner)(name)(website)(slogan)(philosophy)(background)(logo_256)(telegram)(steemit)(twitter)(wechat)(reserved_1)(reserved_2)(reserved_3))
+        };
+
+        typedef multi_index<"proxies"_n, proxy> proxy_table;
+
+        tlsproxyinfo(name self, name code, datastream<const char*> ds);
+
+        ~tlsproxyinfo();
+
+    protected:
+        proxy_table proxies;
+};

--- a/telos.proxy/src/telos.proxy.cpp
+++ b/telos.proxy/src/telos.proxy.cpp
@@ -1,0 +1,123 @@
+/**
+ * Supports chain storage of proxies
+ * 
+ * @author Marlon Williams
+ * @copyright defined in telos/LICENSE.txt
+ */
+
+#include <telos.proxy/telos.proxy.hpp>
+
+tlsproxyinfo::tlsproxyinfo(name self, name code, datastream<const char*> ds) : 
+contract(self, code, ds), 
+proxies(self, self.value)
+{
+
+}
+
+tlsproxyinfo::~tlsproxyinfo() {
+}
+
+/**
+ *  Set proxy info
+ *
+ *  @param proxy - the proxy account name
+ *  @param name - human readable name
+ *  @param slogan - a short description
+ *  @param philosophy - voting philosophy
+ *  @param background - optional. who is the proxy?
+ *  @param website - optional. url to website
+ *  @param logo_256 - optional. url to an image with the size of 256 x 256 px
+ *  @param telegram - optional. telegram account name
+ *  @param steemit - optional. steemit account name
+ *  @param twitter - optional. twitter account name
+ *  @param wechat - optional. wechat account name
+ */
+void tlsproxyinfo::set(const name proxy, std::string name, std::string slogan, std::string philosophy, std::string background, std::string website, std::string logo_256, std::string telegram, std::string steemit, std::string twitter, std::string wechat, std::string reserved_1, std::string reserved_2, std::string reserved_3) {
+    // Validate input
+    eosio_assert(!name.empty(), "name required");
+    eosio_assert(name.length() <= 256, "name too long");
+
+    eosio_assert(slogan.length() <= 256, "slogan too long");
+
+    eosio_assert(philosophy.length() <= 256, "philosophy too long");
+
+    eosio_assert(background.length() <= 256, "background too long");
+
+    eosio_assert(website.length() <= 256, "website too long");
+    if (!website.empty()) {
+        eosio_assert(website.substr(0, 4) == "http", "website should begin with http");
+    }
+
+    eosio_assert(logo_256.length() <= 256, "logo_256 too long");
+    if (!logo_256.empty()) {
+        eosio_assert(logo_256.substr(0, 4) == "http", "logo_256 should begin with http");
+    }
+
+    eosio_assert(telegram.length() <= 64, "telegram too long");
+    eosio_assert(steemit.length() <= 64, "steemit too long");
+    eosio_assert(twitter.length() <= 64, "twitter too long");
+    eosio_assert(wechat.length() <= 64, "wechat too long");
+
+    // Require auth from the proxy account
+    require_auth(proxy);
+
+    // Check if exists
+    auto current = proxies.find(proxy.value);
+
+    // Update
+    if (current != proxies.end()) {
+        proxies.modify(current, proxy, [&]( auto& i ) {
+            i.owner = proxy;
+            i.name = name;
+            i.website = website;
+            i.slogan = slogan;
+            i.philosophy = philosophy;
+            i.background = background;
+            i.logo_256 = logo_256;
+            i.telegram = telegram;
+            i.steemit = steemit;
+            i.twitter = twitter;
+            i.wechat = wechat;
+            i.reserved_1 = reserved_1;
+            i.reserved_2 = reserved_2;
+            i.reserved_3 = reserved_3;
+        });
+
+    // Insert
+    } else {
+        proxies.emplace(proxy, [&]( auto& i ) {
+            i.owner = proxy;
+            i.name = name;
+            i.website = website;
+            i.slogan = slogan;
+            i.philosophy = philosophy;
+            i.background = background;
+            i.logo_256 = logo_256;
+            i.telegram = telegram;
+            i.steemit = steemit;
+            i.twitter = twitter;
+            i.wechat = wechat;
+            i.reserved_1 = reserved_1;
+            i.reserved_2 = reserved_2;
+            i.reserved_3 = reserved_3;
+        });
+    }
+}
+
+/**
+ * Remove all proxy info.
+ *g
+ * @param proxy - the proxy account name.
+ */
+void tlsproxyinfo::remove(const name proxy) {
+    // Require auth from the proxy account
+    require_auth(proxy);
+
+    // Delete record
+    auto lookup = proxies.find(proxy.value);
+    if (lookup != proxies.end()) {
+        proxies.erase(lookup);
+    }
+}
+
+EOSIO_DISPATCH(tlsproxyinfo, (set)(remove))


### PR DESCRIPTION
Allows users to register proxy info (name, website, etc, etc). Used to enable this functionality: https://www.youtube.com/watch?v=wFB-Hpgpep0&t=1s