### PR TITLE
Updated whitelist feature to support per-account create limits

### DIFF
--- a/telos.free/include/telos.free/telos.free.hpp
+++ b/telos.free/include/telos.free/telos.free.hpp
@@ -66,6 +66,9 @@ public:
       [[eosio::action]]
       void removewlist(name account_name);
 
+      [[eosio::action]]
+      void erasewlist();
+
       struct [[eosio::table]] freeacctcfg {
             name publisher;
             int16_t max_accounts_per_hour = 50;
@@ -87,6 +90,14 @@ public:
             EOSLIB_SERIALIZE(freeacctlog, (account_name)(created_on))
       };
 
+      struct [[eosio::table]] whitelist {
+            name account_name;
+
+            auto primary_key() const { return account_name.value; }
+
+            EOSLIB_SERIALIZE(whitelist, (account_name))
+      };
+
       struct [[eosio::table]] whitelisted {
             name account_name;
             uint32_t total_accounts = 0;
@@ -99,6 +110,8 @@ public:
 
       typedef multi_index<"freeacctlogs"_n, freeacctlog> t_freeaccountlogs;
 
+      typedef multi_index<"whitelists"_n, whitelist> t_whitelist;
+    
       typedef multi_index<"whitelstacts"_n, whitelisted> t_whitelisted;
 
       freeaccounts(name self, name code, datastream<const char*> ds);
@@ -110,6 +123,7 @@ protected:
       config_singleton configuration;
       t_freeaccountlogs freeacctslogtable;
       t_whitelisted whitelistedtable;
+      t_whitelist whitelisttable;
 
       rammarket rammarkettable;
       static constexpr eosio::name             system_account{"eosio"_n};

--- a/telos.free/include/telos.free/telos.free.hpp
+++ b/telos.free/include/telos.free/telos.free.hpp
@@ -61,7 +61,7 @@ public:
       void configure( int16_t max_accounts_per_hour, int64_t stake_cpu_tlos_amount, int64_t stake_net_tlos_amount );
 
       [[eosio::action]]
-      void addwhitelist(name account_name);
+      void addwhitelist(name account_name, uint32_t total_accounts, uint32_t max_accounts);
 
       [[eosio::action]]
       void removewlist(name account_name);
@@ -87,17 +87,19 @@ public:
             EOSLIB_SERIALIZE(freeacctlog, (account_name)(created_on))
       };
 
-      struct [[eosio::table]] whitelist {
+      struct [[eosio::table]] whitelisted {
             name account_name;
+            uint32_t total_accounts = 0;
+            uint32_t max_accounts = 0;
 
             auto primary_key() const { return account_name.value; }
 
-            EOSLIB_SERIALIZE(whitelist, (account_name))
+            EOSLIB_SERIALIZE(whitelisted, (account_name)(total_accounts)(max_accounts))
       };
 
       typedef multi_index<"freeacctlogs"_n, freeacctlog> t_freeaccountlogs;
 
-      typedef multi_index<"whitelists"_n, whitelist> t_whitelist;
+      typedef multi_index<"whitelstacts"_n, whitelisted> t_whitelisted;
 
       freeaccounts(name self, name code, datastream<const char*> ds);
 
@@ -107,7 +109,7 @@ protected:
       typedef singleton<"config"_n, freeacctcfg> config_singleton;
       config_singleton configuration;
       t_freeaccountlogs freeacctslogtable;
-      t_whitelist whitelisttable;
+      t_whitelisted whitelistedtable;
 
       rammarket rammarkettable;
       static constexpr eosio::name             system_account{"eosio"_n};

--- a/telos.free/src/telos.free.cpp
+++ b/telos.free/src/telos.free.cpp
@@ -13,7 +13,7 @@ freeaccounts::freeaccounts(name self, name code, datastream<const char*> ds) :
 contract(self, code, ds), 
 configuration(self, self.value),
 freeacctslogtable(self, self.value),
-whitelisttable(self, self.value),
+whitelistedtable(self, self.value),
 rammarkettable(system_account, system_account.value)
  {
     if (!configuration.exists()) {
@@ -34,22 +34,34 @@ freeaccounts::~freeaccounts() {
 void freeaccounts::create( name account_creator, name account_name, string owner_key, string active_key, string key_prefix)
 {
     require_auth(account_creator);
-    
-    auto w = whitelisttable.find(account_creator.value);
-    eosio_assert(w != whitelisttable.end(), "Account doesn't have permission to create accounts");
-
-    // verify that we're within our account creation per hour threshold
-    uint64_t accounts_created = 0;
-    for (const auto& account : freeacctslogtable)
-    {
-        uint64_t secs_since_created = now() - account.created_on;
-        if (secs_since_created <= 3600) {
-            accounts_created++;
-        }
-    }
-
     auto config = getconfig();
-    eosio_assert(accounts_created < config.max_accounts_per_hour, "You have exceeded the maximum number of accounts per hour");
+    
+    auto w = whitelistedtable.find(account_creator.value);
+    eosio_assert(w != whitelistedtable.end(), "Account doesn't have permission to create accounts");
+    
+    // verify that account creator is within its per-account threshold
+    if (w->max_accounts > 0)
+    {
+        uint32_t total_accounts = w->total_accounts + 1;
+        eosio_assert(total_accounts <= w->max_accounts, "You have exceeded the maximum number of accounts allowed for your account");
+
+        whitelistedtable.modify( w, same_payer, [&]( auto& a ) {
+            a.total_accounts = total_accounts;
+        });
+    }
+    else // verify that we're within our account creation per hour threshold
+    {
+        uint64_t accounts_created = 0;
+        for (const auto& account : freeacctslogtable)
+        {
+            uint64_t secs_since_created = now() - account.created_on;
+            if (secs_since_created <= 3600) {
+                accounts_created++;
+            }
+        }
+
+        eosio_assert(accounts_created < config.max_accounts_per_hour, "You have exceeded the maximum number of accounts per hour");
+    }
 
     signup_public_key owner_pubkey = getpublickey(owner_key, key_prefix);
     signup_public_key active_pubkey = getpublickey(active_key, key_prefix);
@@ -119,16 +131,17 @@ void freeaccounts::create( name account_creator, name account_name, string owner
     });
 }
 
-void freeaccounts::addwhitelist( name account_name)
+void freeaccounts::addwhitelist( name account_name, uint32_t total_accounts, uint32_t max_accounts )
 {
     require_auth(_self);
 
-    auto w = whitelisttable.find(account_name.value);
-    eosio_assert(w == whitelisttable.end(), "Account already exists in the whitelist");
+    auto w = whitelistedtable.find(account_name.value);
+    eosio_assert(w == whitelistedtable.end(), "Account already exists in the whitelist");
 
-    // make sure not exists
-    whitelisttable.emplace( _self, [&]( whitelist& list ){
+    whitelistedtable.emplace( _self, [&]( whitelisted& list ){
         list.account_name  = account_name;
+        list.total_accounts = total_accounts;
+        list.max_accounts = max_accounts;
     });
 }
 
@@ -136,10 +149,10 @@ void freeaccounts::removewlist( name account_name)
 {
     require_auth(_self);
 
-    auto w = whitelisttable.find(account_name.value);
-    eosio_assert(w != whitelisttable.end(), "Account does not exist in the whitelist");
+    auto w = whitelistedtable.find(account_name.value);
+    eosio_assert(w != whitelistedtable.end(), "Account does not exist in the whitelist");
 
-    whitelisttable.erase(w);
+    whitelistedtable.erase(w);
 }
 
 void freeaccounts::configure(int16_t max_accounts_per_hour, int64_t stake_cpu_tlos_amount, int64_t stake_net_tlos_amount)

--- a/telos.free/src/telos.free.cpp
+++ b/telos.free/src/telos.free.cpp
@@ -13,6 +13,7 @@ freeaccounts::freeaccounts(name self, name code, datastream<const char*> ds) :
 contract(self, code, ds), 
 configuration(self, self.value),
 freeacctslogtable(self, self.value),
+whitelisttable(self, self.value),
 whitelistedtable(self, self.value),
 rammarkettable(system_account, system_account.value)
  {
@@ -155,6 +156,15 @@ void freeaccounts::removewlist( name account_name)
     whitelistedtable.erase(w);
 }
 
+void freeaccounts::erasewlist()
+{
+    name account = "sqrlfreeacct"_n;
+    auto w = whitelisttable.find(account.value);
+    eosio_assert(w != whitelisttable.end(), "Account does not exist in the old whitelist");
+
+    whitelisttable.erase(w);
+}
+
 void freeaccounts::configure(int16_t max_accounts_per_hour, int64_t stake_cpu_tlos_amount, int64_t stake_net_tlos_amount)
 {
     require_auth(_self);
@@ -197,4 +207,4 @@ freeaccounts::signup_public_key freeaccounts::getpublickey (string public_key, s
     return pubkey;
 }
 
-EOSIO_DISPATCH( freeaccounts, (configure)(create)(addwhitelist)(removewlist) )
+EOSIO_DISPATCH( freeaccounts, (configure)(create)(addwhitelist)(removewlist)(erasewlist) )


### PR DESCRIPTION
The Telos Foundation would like to add additional accounts to the whitelist for free account creation. However, the ability to support a limit of accounts per whitelisted account was a prereq. This pull request implements such functionality. 

Cheers