### PR TITLE
Refactor eosio.amend::closeprop to correct error where number of voters is used to determine voting thresholds instead of number of TLOS

### DIFF
--- a/eosio.amend/src/eosio.amend.cpp
+++ b/eosio.amend/src/eosio.amend.cpp
@@ -277,14 +277,14 @@ void ratifyamend::closeprop(uint64_t sub_id) {
     asset non_abstain_votes = (prop.yes_count + prop.no_count); 
 
     //pass thresholds
-    uint64_t voters_pass_thresh = (e->total_voters * configs_struct.threshold_pass_voters) / 100;
+    uint64_t voters_pass_thresh = (e->supply * configs_struct.threshold_pass_voters) / 100;
     asset votes_pass_thresh = (non_abstain_votes * configs_struct.threshold_pass_votes) / 100;
 
     //fee refund thresholds
-    uint64_t voters_fee_thresh = (e->total_voters * configs_struct.threshold_fee_voters) / 100; 
+    uint64_t voters_fee_thresh = (e->supply * configs_struct.threshold_fee_voters) / 100; 
     asset votes_fee_thresh = (total_votes * configs_struct.threshold_fee_votes) / 100; 
 
-    if( prop.yes_count >= votes_fee_thresh && prop.unique_voters >= voters_fee_thresh) {
+    if( prop.yes_count >= votes_fee_thresh && total_votes >= voters_fee_thresh) {
         action(permission_level{ _self, "active"_n }, "eosio.token"_n, "transfer"_n, make_tuple(
             _self,
             sub.proposer,
@@ -294,7 +294,7 @@ void ratifyamend::closeprop(uint64_t sub_id) {
     }
 
     uint8_t new_status = 2;
-    if( prop.yes_count > votes_pass_thresh && prop.unique_voters >= voters_pass_thresh ) {
+    if( prop.yes_count > votes_pass_thresh && total_votes >= voters_pass_thresh ) {
         update_doc(sub.document_id, sub.new_clause_nums, sub.new_ipfs_urls);
         new_status = uint8_t(1);
     }

--- a/eosio.amend/src/eosio.amend.cpp
+++ b/eosio.amend/src/eosio.amend.cpp
@@ -277,11 +277,11 @@ void ratifyamend::closeprop(uint64_t sub_id) {
     asset non_abstain_votes = (prop.yes_count + prop.no_count); 
 
     //pass thresholds
-    uint64_t voters_pass_thresh = (e->supply * configs_struct.threshold_pass_voters) / 100;
+    uint64_t voters_pass_thresh = (e->supply.amount * configs_struct.threshold_pass_voters) / 100;
     asset votes_pass_thresh = (non_abstain_votes * configs_struct.threshold_pass_votes) / 100;
 
     //fee refund thresholds
-    uint64_t voters_fee_thresh = (e->supply * configs_struct.threshold_fee_voters) / 100; 
+    uint64_t voters_fee_thresh = (e->supply.amount * configs_struct.threshold_fee_voters) / 100; 
     asset votes_fee_thresh = (total_votes * configs_struct.threshold_fee_votes) / 100; 
 
     if( prop.yes_count >= votes_fee_thresh && total_votes >= voters_fee_thresh) {


### PR DESCRIPTION
## Change Description
eosio.amend::closeprop is using the number of unique voters to calculate the thresholds for both passage and deposit fee refund of a ratify proposal. This PR changes that threshold calculation to use "voteable TLOS" as clearly stated in the TBNOA Clause 38 (expressed as VOTE token supply) 

## Deployment Changes
- [ ] Deployment Changes


## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions
