### PR TITLE
fixes to asset type checking against uint64_t

### DIFF
--- a/contracts/eosio.amend/src/eosio.amend.cpp
+++ b/contracts/eosio.amend/src/eosio.amend.cpp
@@ -315,7 +315,7 @@ void ratifyamend::closeprop(uint64_t sub_id) {
     uint64_t voters_fee_thresh = (e->supply.amount * configs_struct.threshold_fee_voters) / 100; 
     asset votes_fee_thresh = (total_votes * configs_struct.threshold_fee_votes) / 100; 
 
-    if( prop.yes_count >= votes_fee_thresh && total_votes >= voters_fee_thresh) {
+    if( prop.yes_count >= votes_fee_thresh && total_votes.amount >= voters_fee_thresh) {
         action(permission_level{ _self, "active"_n }, "eosio.token"_n, "transfer"_n, make_tuple(
             _self,
             sub.proposer,
@@ -325,7 +325,7 @@ void ratifyamend::closeprop(uint64_t sub_id) {
     }
 
     uint8_t new_status = 2;
-    if( prop.yes_count > votes_pass_thresh && total_votes >= voters_pass_thresh ) {
+    if( prop.yes_count > votes_pass_thresh && total_votes.amount >= voters_pass_thresh ) {
         update_doc(sub.document_id, sub.new_clause_nums, sub.new_ipfs_urls);
         new_status = uint8_t(1);
     }

--- a/contracts/eosio.saving/src/worker.proposals.cpp
+++ b/contracts/eosio.saving/src/worker.proposals.cpp
@@ -203,7 +203,7 @@ void workerproposal::claim(uint64_t sub_id) {
     auto updated_fee = sub.fee;
 
     // print("\n GET FEE BACK WHEN <<<< ", prop.yes_count, " >= ", votes_fee_thresh," && ", total_votes, " >= ", voters_fee_thresh);
-    if( sub.fee && prop.yes_count.amount > 0 && prop.yes_count >= votes_fee_thresh && total_votes >= voters_fee_thresh) {
+    if( sub.fee && prop.yes_count.amount > 0 && prop.yes_count >= votes_fee_thresh && total_votes.amount >= voters_fee_thresh) {
         asset the_fee = asset(int64_t(sub.fee), symbol("TLOS", 4));
         if(sub.receiver == sub.proposer){
             outstanding += the_fee;
@@ -219,7 +219,7 @@ void workerproposal::claim(uint64_t sub_id) {
     }
 
     // print("\n GET MUNI WHEN <<<< ", prop.yes_count, " > ", votes_pass_thresh, " && ", total_votes, " >= ", voters_pass_thresh);
-    if( prop.yes_count > votes_pass_thresh && total_votes >= voters_pass_thresh ) {
+    if( prop.yes_count > votes_pass_thresh && total_votes.amount >= voters_pass_thresh ) {
         outstanding += asset(int64_t(sub.amount), symbol("TLOS", 4));
     }
     


### PR DESCRIPTION
Resolving errors while compiling. Example:

```
eosio.contracts/contracts/eosio.saving/src/worker.proposals.cpp:206:99: error: invalid operands to binary expression (eosio::asset and uint64_t
      (aka unsigned long long))
    if( sub.fee && prop.yes_count.amount > 0 && prop.yes_count >= votes_fee_thresh && total_votes >= voters_fee_thresh) {
                                                                                      ~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~
```