### PR TITLE
Hotfix/missed blocks

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -60,7 +60,7 @@ namespace eosiosystem {
     * the number that is set on the main net is 1,000,000.
 	* This value should be changed by ABPs before launching.
     */
-   const uint32_t block_num_network_activation = 25;
+   const uint32_t block_num_network_activation = 1000;
 
    const uint64_t max_bpay_rate = 6000;
    const uint64_t max_worker_monthly_amount = 1'000'000'0000;

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -60,7 +60,7 @@ namespace eosiosystem {
     * the number that is set on the main net is 1,000,000.
 	* This value should be changed by ABPs before launching.
     */
-   const uint32_t block_num_network_activation = 1000;
+   const uint32_t block_num_network_activation = 25;
 
    const uint64_t max_bpay_rate = 6000;
    const uint64_t max_worker_monthly_amount = 1'000'000'0000;

--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -18,7 +18,7 @@ namespace eosiosystem {
    void system_contract::onblock( ignore<block_header> ) {
         using namespace eosio;
 
-        require_auth(_self);
+        require_auth(get_self());
 
         block_timestamp timestamp;
         name producer;
@@ -34,7 +34,6 @@ namespace eosiosystem {
         }
      
         if (_gstate.last_pervote_bucket_fill == time_point()) _gstate.last_pervote_bucket_fill = current_time_point();
-
 
         if(check_missed_blocks(timestamp, producer)) {
             update_missed_blocks_per_rotation();
@@ -109,8 +108,6 @@ namespace eosiosystem {
    }
 
    void system_contract::claimrewards_snapshot() {
-        require_auth("eosio"_n);
-
         check(_gstate.thresh_activated_stake_time > time_point(), "cannot take snapshot until chain is activated");
 
         //skips action, since there are no rewards to claim
@@ -131,7 +128,7 @@ namespace eosiosystem {
             auto new_tokens = to_workers + to_producers;
 
             //NOTE: This line can cause failure if eosio.tedp doesn't have a balance emplacement
-            asset tedp_balance = eosio::token::get_balance("eosio.token"_n, tedp_account, symbol_code("TLOS"));
+            asset tedp_balance = eosio::token::get_balance(token_account, tedp_account, core_symbol().code());
             
             int64_t transfer_tokens = 0;
             int64_t issue_tokens = 0;

--- a/contracts/eosio.system/src/system_kick.cpp
+++ b/contracts/eosio.system/src/system_kick.cpp
@@ -9,7 +9,6 @@ namespace eosiosystem {
   bool system_contract::crossed_missed_blocks_threshold(uint32_t amountBlocksMissed, uint32_t schedule_size) {
     if (schedule_size <= 1) return false;
 
-    // 6hrs
     auto timeframe = (_grotation.next_rotation_time.to_time_point() - _grotation.last_rotation_time.to_time_point()).to_seconds();
     // Total blocks that can be produced in a cycle
     auto maxBlocksPerCycle = (schedule_size - 1) * MAX_BLOCK_PER_CYCLE;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

This PR fixes issue #66. After the `eosio.contracts v1.7.0` update the `eosio.system` missed blocks calculator (MBC) failed to tally block producer missed blocks. This issue was caused due to a recent refactor of the MBC in PR #63. When Block One deprecated `eosiolib` in `eosio.cdt v1.6.x` they removed the `capi` datatypes and methods from `eosio-cpp`. See the following [guide](https://eosio.github.io/eosio.cdt/latest/upgrading/1.5-to-1.6) for details. The `check_missed_blocks()` method requires `get_active_producers()` to compare `schedulemetr.producer_metrics` to the currently active schedule. 

```
  bool system_contract::check_missed_blocks(block_timestamp timestamp, name producer) {
    if (producer == "eosio"_n) {
      _gschedule_metrics.block_counter_correction++;
      _gschedule_metrics.last_onblock_caller = producer;
      return false;
    }

    auto producers_schedule = get_active_producers();
    bool is_activated = _gstate.last_producer_schedule_size == producers_schedule.size() && 
    is_new_schedule_activated(producers_schedule);

    if (!is_activated) {
       [code]
    }
```

This deprecation required the refactor of the `is_new_schedule_activated(vector<name>)` method. Which compares `producer_metrics` to the active schedule. If the two vectors are different, then the new producers are emplaced into the table and the calculation starts over on the next block.

Due to a bug in `eosio.cdt` versions `v1.6.0`, `v1.6.1`, and `v1.6.2` the `get_active_producers()` method would form a vector of the appropriate size, but would have malformed `name`s in it. Thus `is_new_schedule_activated` would always return false. This bug was resolved in `eosio.cdt v1.6.3` and only a recompile with that version is required to resolve issue #66. See the `eosio.cdt v1.6.3` release for more information on the [fix](https://github.com/EOSIO/eosio.cdt/releases/tag/v1.6.3). This PR contains some small changes found during the review of the feature. These changes are recommended for merge because they aim to optimize CPU usage.

