### PR TITLE
Addition of a Configurable Limit to Prevent the Exploit of REX Loans in EOSIO

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -420,6 +420,28 @@ namespace eosiosystem {
    typedef eosio::multi_index<"rexconfig"_n, rex_config> rex_config_table;
 
    /**
+    * `rex_whitelist` structure within the rex whitelisting table.
+    * 
+    * @details A rex whitelist table entry is defined by:
+    * - `wid` - whitelist id key
+    * - `waccount_name` - configuration item name
+    */
+    struct [[eosio::table,eosio::contract("eosio.system")]] rex_whitelist {
+	uint64_t   	wid = 0;
+	name		waccount_name;
+
+	uint64_t primary_key()const { return wid; }
+    };
+
+   /**
+    * Rex whitelist table
+    *
+    * @details The rex whitelist table is storing only one instance of rex_whitelist which stores
+    * account names whitelisted from REX resource loan limiting.
+    */
+   typedef eosio::multi_index<"rexwhitelist"_n, rex_whitelist> rex_whitelist_table;
+
+   /**
     * `rex_pool` structure underlying the rex pool table.
     *
     * @details A rex pool table entry is defined by:

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -405,7 +405,7 @@ namespace eosiosystem {
     */
     struct [[eosio::table,eosio::contract("eosio.system")]] rex_config {
 	uint8_t   	config_id = 0;
-	name		config_item_name;
+	std::string	config_item_name;
 	uint64_t	config_item_value = 0;
 
 	uint8_t primary_key()const { return config_id; }
@@ -777,6 +777,36 @@ namespace eosiosystem {
          [[eosio::action]]
          void delegatebw( const name& from, const name& receiver,
                           const asset& stake_net_quantity, const asset& stake_cpu_quantity, bool transfer );
+
+	  /**
+          * Configure REX borrowing limit.
+          *
+          * @details Allows configuration of the REX resource borrowing limit via limit_percentage.
+          *
+          * @param limit_percentage - The borrowing limit as a floating point value.
+          */
+         [[eosio::action]]
+         void rexlimit( double limit_percentage );
+
+	  /**
+          * Add a REX limit whitelist entry.
+          *
+          * @details Adds an account name to the REX limit whitelisting table.
+          *
+          * @param name - The name of the account to be added to the whitelist.
+          */
+         [[eosio::action]]
+         void addrexwlist( const name& allowed );
+
+	  /**
+          * Remove a REX limit whitelist entry.
+          *
+          * @details Removes an account name from the REX limit whitelisting table.
+          *
+          * @param name - The name of the account to be removed from the whitelist.
+          */
+         [[eosio::action]]
+         void remrexwlist( const name& allowed );
 
          /**
           * Setrex action.

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -401,7 +401,7 @@ namespace eosiosystem {
     * @details A rex configuration table entry is defined by:
     * - `cid` - configuration id key
     * - `citem_name` - configuration item name
-    * - `cvalue` - configuration value (uint8_t)
+    * - `cvalue` - configuration value (uint64_t)
     */
     struct [[eosio::table,eosio::contract("eosio.system")]] rex_config {
 	uint8_t   	cid = 0;

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -399,16 +399,16 @@ namespace eosiosystem {
     * `rex_config` structure within the rex configuration table.
     * 
     * @details A rex configuration table entry is defined by:
-    * - `cid` - configuration id key
-    * - `citem_name` - configuration item name
-    * - `cvalue` - configuration value (uint64_t)
+    * - `config_id` - configuration id key
+    * - `config_item_name` - configuration item name
+    * - `config_item_value` - configuration value (uint64_t)
     */
     struct [[eosio::table,eosio::contract("eosio.system")]] rex_config {
-	uint8_t   	cid = 0;
-	name		citem_name;
-	uint64_t	cvalue = 0;
+	uint8_t   	config_id = 0;
+	name		config_item_name;
+	uint64_t	config_item_value = 0;
 
-	uint8_t primary_key()const { return cid; }
+	uint8_t primary_key()const { return config_id; }
     };
 
    /**
@@ -423,14 +423,14 @@ namespace eosiosystem {
     * `rex_whitelist` structure within the rex whitelisting table.
     * 
     * @details A rex whitelist table entry is defined by:
-    * - `wid` - whitelist id key
-    * - `waccount_name` - configuration item name
+    * - `whitelist_id` - whitelist id key
+    * - `whitelist_account_name` - configuration item name
     */
     struct [[eosio::table,eosio::contract("eosio.system")]] rex_whitelist {
-	uint64_t   	wid = 0;
-	name		waccount_name;
+	uint64_t   	whitelist_id = 0;
+	name		whitelist_account_name;
 
-	uint64_t primary_key()const { return wid; }
+	uint64_t primary_key()const { return whitelist_id; }
     };
 
    /**

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -396,6 +396,30 @@ namespace eosiosystem {
    typedef eosio::multi_index< "refunds"_n, refund_request >      refunds_table;
 
    /**
+    * `rex_config` structure within the rex configuration table.
+    * 
+    * @details A rex configuration table entry is defined by:
+    * - `cid` - configuration id key
+    * - `citem_name` - configuration item name
+    * - `cvalue` - configuration value (uint8_t)
+    */
+    struct [[eosio::table,eosio::contract("eosio.system")]] rex_config {
+	uint8_t   	cid = 0;
+	name		citem_name;
+	uint64_t	cvalue = 0;
+
+	uint8_t primary_key()const { return cid; }
+    };
+
+   /**
+    * Rex configuration table
+    *
+    * @details The rex configuration table is storing only one instance of rex_config which stores
+    * configuration items for the REX system.
+    */
+   typedef eosio::multi_index<"rexconfig"_n, rex_config> rex_config_table;
+
+   /**
     * `rex_pool` structure underlying the rex pool table.
     *
     * @details A rex pool table entry is defined by:

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -641,6 +641,15 @@ namespace eosiosystem {
 	 const uint64_t configured_rex_limit = rexc_itr->cvalue;
       }
 
+      rex_whitelist_table rex_whitelist_local( _self, _self.value);
+      if ( rex_whitelist_local.begin() != rex_whitelist_local.end() ) {
+	 for ( auto rexwl_itr = rex_whitelist_local.begin(); rexwl_itr != rex_whitelist_local.end(); rexwl_itr++) {
+	    if ( rexwl_itr->waccount_name == from ) {
+	       const uint64_t configured_rex_limit = 1; /// If from account matches a whitelisted name then allow unlimited REX loans.
+	    }
+	 }
+      }
+
       auto rexp_itr = _rexpool.begin();
       const int64_t total_rex = rexp_itr->total_rex.amount;
       const int64_t max_rex_limit = total_rex / configured_rex_limit;

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -634,9 +634,16 @@ namespace eosiosystem {
                                                                  payment.amount );
       check( payment.amount < rented_tokens, "loan price does not favor renting" );
 
+      const uint64_t configured_rex_limit = 1000;  /// Set default fractional divisor for REX limit to 1000 (0.1%).
+      rex_config_table rex_config_local( _self, _self.value);
+      auto rexc_itr = rex_config_local.find( 1 );
+      if ( rexc_itr != rex_config_local.end() ) {
+	 const uint64_t configured_rex_limit = rexc_itr->cvalue;
+      }
+
       auto rexp_itr = _rexpool.begin();
       const int64_t total_rex = rexp_itr->total_rex.amount;
-      const int64_t max_rex_limit = total_rex / 300;
+      const int64_t max_rex_limit = total_rex / configured_rex_limit;
       check ( rented_tokens < max_rex_limit, "loan greater than maximum rental limit" );
 
       add_loan_to_rex_pool( payment, rented_tokens, true );

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -633,6 +633,12 @@ namespace eosiosystem {
                                                                  pool->total_unlent.amount,
                                                                  payment.amount );
       check( payment.amount < rented_tokens, "loan price does not favor renting" );
+
+      auto rexp_itr = _rexpool.begin();
+      const int64_t total_rex = rexp_itr->total_rex.amount;
+      const int64_t max_rex_limit = total_rex / 300;
+      check ( rented_tokens < max_rex_limit, "loan greater than maximum rental limit" );
+
       add_loan_to_rex_pool( payment, rented_tokens, true );
 
       table.emplace( from, [&]( auto& c ) {

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -634,18 +634,18 @@ namespace eosiosystem {
                                                                  payment.amount );
       check( payment.amount < rented_tokens, "loan price does not favor renting" );
 
-      const uint64_t configured_rex_limit = 1000;  /// Set default fractional divisor for REX limit to 1000 (0.1%).
+      uint64_t configured_rex_limit = 1000;  /// Set default fractional divisor for REX limit to 1000 (0.1%).
       rex_config_table rex_config_local( _self, _self.value);
       auto rexc_itr = rex_config_local.find( 1 );
       if ( rexc_itr != rex_config_local.end() ) {
-	 const uint64_t configured_rex_limit = rexc_itr->cvalue;
+	 configured_rex_limit = rexc_itr->config_item_value;
       }
 
       rex_whitelist_table rex_whitelist_local( _self, _self.value);
       if ( rex_whitelist_local.begin() != rex_whitelist_local.end() ) {
 	 for ( auto rexwl_itr = rex_whitelist_local.begin(); rexwl_itr != rex_whitelist_local.end(); rexwl_itr++) {
-	    if ( rexwl_itr->waccount_name == from ) {
-	       const uint64_t configured_rex_limit = 1; /// If from account matches a whitelisted name then allow unlimited REX loans.
+	    if ( rexwl_itr->whitelist_account_name == from ) {
+	       configured_rex_limit = 1; /// If from account matches a whitelisted name then allow unlimited REX loans.
 	    }
 	 }
       }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This change adds a configurable limit to the eosio.system contract to prevent a potential exploit of REX resource availability to cause a Denial-Of-Service condition to the entire blockchain network. The default limit is set at 0.1% of all available REX resources and can be overridden via a configuration table value. Trusted accounts can also be added to a whitelist table to allow loans of greater value than the configured limit. 

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->
None.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
Adds "rexconfig" and "rexwhitelist" system tables with the ability to set config_item_value[1] and whitelist_account_name[n] attributes to set the fractional divisor for the REX limit and add whitelisted account names respectively. 
Also adds inline actions eosio::rexlimit, eosio::addrexwlist and eosio::remrexwlist to allow table value modification. 

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
